### PR TITLE
add pump as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "mirror-folder": "^2.1.1",
     "ms": "^2.1.1",
     "prettier-bytes": "^1.0.4",
+    "pump": "^3.0.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-file-drop": "^0.1.9",


### PR DESCRIPTION
Because it's actually used as a dependency, e.g. https://github.com/cabal-club/cabal-desktop/blob/c19e1e31fb6834be742a4899e09d2b1539ef1de9/app/actions.js#L4

Keep up the good work!