### PR TITLE
Add the most basic desktop notification for new messages when in background

### DIFF
--- a/app/actions.js
+++ b/app/actions.js
@@ -81,6 +81,12 @@ export const getMessages = ({addr, channel, count}) => dispatch => {
     if (err) return console.trace(err)
     rows.map((arr) => {
       arr.map((row) => {
+        if (!document.hasFocus()) {
+          window.Notification.requestPermission()
+          new window.Notification(row.value.author, {
+            body: row.value.content
+          })
+        }
         cabal.messages.push({
           type: row.value.type,
           time: strftime('%H:%M', new Date(row.value.time)),


### PR DESCRIPTION
Fixes #11

This add a desktop notification when a new message comes in to the current channel.

I can see adding options to disable or customize this feature in the future. But for now while message frequency is low this will trigger for all messages when the client is in the background.

<img width="370" alt="screen shot 2018-06-08 at 11 19 30 pm" src="https://user-images.githubusercontent.com/40796/41187202-6f518e8e-6b72-11e8-9a2a-a30e6569a8c9.png">
