### PR TITLE
Bump cabal-node from 2.0.1 to 2.3.0 to get channel sorting & misc fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "webpack-node-externals": "^1.6.0"
   },
   "dependencies": {
-    "cabal-node": "^2.0.1",
+    "cabal-node": "^2.3.0",
     "cat-names": "^1.0.2",
     "dat-encoding": "^5.0.1",
     "discovery-swarm": "^5.1.1",


### PR DESCRIPTION
Tested this manually and found no problems.