### PR TITLE
Make messages wrap by word and not character by character

### DIFF
--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -431,7 +431,7 @@ form {
 
   .messages__item__metadata p.text {
     margin-bottom: 0.33rem;
-    word-break: break-all;
+    word-break: break-word;
   }
 
   .composerContainer {


### PR DESCRIPTION
`break-all` does char-by-char.
Use `break-word` instead which does word-by-word but allows very long words to be broken.