### PR TITLE
Show 100 messages per channel instead of 25

### DIFF
--- a/app/actions.js
+++ b/app/actions.js
@@ -132,7 +132,7 @@ export const viewChannel = ({addr, channel}) => dispatch => {
     channels: cabal.channels
   })
   dispatch({type: 'VIEW_CABAL', addr})
-  dispatch(getMessages({addr, channel, count: 25}))
+  dispatch(getMessages({addr, channel, count: 100}))
   cabal.watcher = cabal.watch(channel, () => {
     dispatch(getMessages({addr, channel, count: 1}))
   })


### PR DESCRIPTION
Since people keep asking where the old messages went.

It is noticeably a bit slower to switch to a channel for the first time (after restarting Cabal).  After that, the channel is already loaded so switching is faster.