### PR TITLE
Improve link styling - remove underline, calmer blue

### DIFF
--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -447,7 +447,13 @@ form {
   }
 
   .messages__item__metadata a.link {
-    color: #004de4;
+    color: #1170c7;
+    text-decoration: none;
+
+    &:hover {
+      color: #24609e;
+      text-decoration: underline;
+    }
   }
 
   .composerContainer {


### PR DESCRIPTION
Haven't found the right shade of blue tbh, but this is a bit less strong than before.

<img width="865" alt="image" src="https://user-images.githubusercontent.com/324440/44196440-da240d80-a133-11e8-866f-9ecc094a4a32.png">
