### PR TITLE
remove window frame and adjust UI to fit

### DIFF
--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -76,12 +76,13 @@ form {
 
 /* Layout: Switch */
 .client__cabals {
-  flex: 0 0 4rem;
+  flex: 0 0 4.8rem;
   background-color: rgba(22, 22, 29, 0.7);
   background-color: #16161d;
   border-right: 1px solid rgba(255, 255, 255, 0.1);
   color: #fff;
   padding: 1rem;
+  padding-top: 44px;
   overflow-y: auto;
 }
 
@@ -99,6 +100,7 @@ form {
 .client__cabals .switcher {
   display: flex;
   flex-direction: column;
+  align-items: center;
 }
 
 .client__cabals .switcher__item {
@@ -168,6 +170,7 @@ form {
     align-items: center;
     width: 13.75rem;
     padding: 1rem;
+    -webkit-app-region: drag;
   }
 
   .session .session__avatar {
@@ -396,6 +399,10 @@ form {
     flex-grow: 1;
     overflow-x: hidden;
     overflow-y: auto;
+  }
+
+  .window__header{
+    -webkit-app-region: drag;
   }
 
   .messages {

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -76,13 +76,13 @@ form {
 
 /* Layout: Switch */
 .client__cabals {
-  flex: 0 0 4.8rem;
+  flex: 0 0 4.4rem;
   background-color: rgba(22, 22, 29, 0.7);
   background-color: #16161d;
   border-right: 1px solid rgba(255, 255, 255, 0.1);
   color: #fff;
   padding: 1rem;
-  padding-top: 44px;
+  padding-top: 36px;
   overflow-y: auto;
 }
 

--- a/index.js
+++ b/index.js
@@ -96,7 +96,10 @@ app.on('ready', () => {
     width: 800,
     height: 600,
     minWidth: 640,
-    minHeight: 395
+    minHeight: 395,
+    frame: false,
+    // titleBarStyle: 'hidden'
+    titleBarStyle: 'hiddenInset'
   })
   win.loadURL(`file://${__dirname}/index.html`)
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))

--- a/index.js
+++ b/index.js
@@ -98,8 +98,8 @@ app.on('ready', () => {
     minWidth: 640,
     minHeight: 395,
     frame: false,
-    // titleBarStyle: 'hidden'
-    titleBarStyle: 'hiddenInset'
+    titleBarStyle: 'hidden'
+    // titleBarStyle: 'hiddenInset'
   })
   win.loadURL(`file://${__dirname}/index.html`)
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))


### PR DESCRIPTION
Probably should have discussed with some mockups, but I got excited. 
Throws the icons out of alignment, but I adjusted them to fit a bit more cleanly. I'm not 100% convinced this is a good change to merge but... 

We can use either `hidden` or `hiddenInset`. I prefer hidden because it makes the minimal adjustments to the sidebar size, but it also makes the mis-alignment more obvious between the user profile pic and the cabal icon.

Maybe the answer here is really an overall re-think of the channel pane because I do think the chromeless ui is a lot more slick and polished looking.