### PR TITLE
Fix Windows path resolution in the webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const nodeExternals = require('webpack-node-externals')
+const path = require('path')
 
 module.exports = {
   entry: './app/index.js',
@@ -16,7 +17,7 @@ module.exports = {
     rules: [
       {
         test: /\.js$/,
-        include: `${__dirname}/app`,
+        include: path.resolve(__dirname, 'app'),
         loader: 'babel-loader',
         query: {
           presets: ['react'],


### PR DESCRIPTION
This code had hardcoded `/` in it. This PR switches to `path.resolve()` instead. It also `require`s path.