### PR TITLE
Open cabal:// urls into the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ https://github.com/cabal-club/cabal-desktop/releases/
 $ git clone https://github.com/cabal-club/cabal-desktop
 $ cd cabal-desktop
 
-$ yarn install             # install dependencies
-$ yarn start               # start the application
+$ npm install             # install dependencies
+$ npm start               # start the application
 ```
 
 ## Distribute
@@ -25,7 +25,7 @@ $ yarn start               # start the application
 build for current platform:
 
 ```
-$ yarn run dist
+$ npm run dist
 ```
 
 build for [multiple platforms](https://www.electron.build/multi-platform-build#docker):

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ https://github.com/cabal-club/cabal-desktop/releases/
 $ git clone https://github.com/cabal-club/cabal-desktop
 $ cd cabal-desktop
 
-$ npm install             # install dependencies
-$ npm start               # start the application
+$ yarn install             # install dependencies
+$ yarn start               # start the application
 ```
 
 ## Distribute
@@ -25,7 +25,7 @@ $ npm start               # start the application
 build for current platform:
 
 ```
-$ npm run dist
+$ yarn run dist
 ```
 
 build for [multiple platforms](https://www.electron.build/multi-platform-build#docker):

--- a/app/actions.js
+++ b/app/actions.js
@@ -132,7 +132,7 @@ export const viewChannel = ({addr, channel}) => dispatch => {
   dispatch(getMessages({addr, channel, count: 100}))
 }
 
-export const changeScreen = ({screen}) => ({ type: 'CHANGE_SCREEN', screen })
+export const changeScreen = ({screen, addr}) => ({ type: 'CHANGE_SCREEN', screen, addr })
 
 export const addCabal = ({addr, input, username}) => dispatch => {
   if (!addr) {

--- a/app/app.js
+++ b/app/app.js
@@ -23,7 +23,6 @@ export class AppScreen extends Component {
 
   render () {
     const {screen} = this.props
-    console.log('screen', screen)
     return (
       <Fragment>
         {screen === 'addCabal'

--- a/app/containers/addCabal.js
+++ b/app/containers/addCabal.js
@@ -45,7 +45,9 @@ class addCabalScreen extends Component {
           className='fun'
           id='add-cabal'
           onKeyDown={this.joinClick.bind(this)}
-          placeholder='Paste cabal:// link and hit Enter' />
+          placeholder='Paste cabal:// link and hit Enter'
+          defaultValue={this.props.addr}
+        />
         <input type='text'
           className='fun'
           id='nickname'

--- a/app/containers/layout.js
+++ b/app/containers/layout.js
@@ -1,8 +1,8 @@
 import React, { Fragment, Component } from 'react'
-import { clipboard } from 'electron'
+import { clipboard, ipcRenderer } from 'electron'
 import { connect } from 'react-redux'
 
-import { getMessages } from '../actions'
+import { changeScreen, getMessages, viewCabal } from '../actions'
 import CabalsList from './cabalsList'
 import Sidebar from './sidebar'
 import WriteContainer from './write'
@@ -10,39 +10,54 @@ import MessagesContainer from './messages'
 
 const mapStateToProps = state => ({
   addr: state.currentCabal,
-  cabal: state.cabals[state.currentCabal]
+  cabal: state.cabals[state.currentCabal],
+  cabals: state.cabals
 })
 
 const mapDispatchToProps = dispatch => ({
-  getMessages: ({addr, channel, count}) => dispatch(getMessages({addr, channel, count}))
+  getMessages: ({addr, channel, count}) => dispatch(getMessages({addr, channel, count})),
+  changeScreen: ({screen, addr}) => dispatch(changeScreen({screen, addr})),
+  viewCabal: ({addr}) => dispatch(viewCabal({addr}))
 })
 
 class LayoutScreen extends Component {
   constructor (props) {
     super(props)
-    this.state = {showEmojiPicker:false}
+    this.state = {showEmojiPicker: false}
     this.shouldAutoScroll = true
     this.scrollTop = 0
     this.composerHeight = 55
-    this.toggleEmoji = this.toggleEmoji.bind(this);
+    this.toggleEmoji = this.toggleEmoji.bind(this)
+    this.handleOpenCabalUrl = this.handleOpenCabalUrl.bind(this)
   }
 
   componentDidMount () {
     var messagesDiv = document.querySelector('.messages')
     if (messagesDiv) messagesDiv.scrollTop = this.scrollTop
-    console.log(this.state)
+    ipcRenderer.on('open-cabal-url', (event, arg) => {
+      this.handleOpenCabalUrl(arg)
+    })
   }
 
   componentDidUpdate (prevProps) {
-    if (prevProps.cabal != this.props.cabal){
+    if (prevProps.cabal != this.props.cabal) {
       this.scrollToBottom()
     }
-    //if you're in the same cabal and a new message arrives we should show a button prompting a scroll to bottom
+    // if you're in the same cabal and a new message arrives we should show a button prompting a scroll to bottom
   }
 
   copyClick () {
     clipboard.writeText('cabal://' + this.props.addr)
     alert('Copied cabal:// link to clipboard! Now give it to people you want to join your Cabal. Only people with the link can join.')
+  }
+
+  handleOpenCabalUrl ({url = ''}) {
+    let addr = url.replace('cabal://', '').trim()
+    if (this.props.cabals[addr]) {
+      this.props.viewCabal({addr})
+    } else {
+      this.props.changeScreen({screen: 'addCabal', addr: url})
+    }
   }
 
   scrollToBottom (force) {
@@ -53,7 +68,7 @@ class LayoutScreen extends Component {
     }
   }
 
-  toggleEmoji(bool) {
+  toggleEmoji (bool) {
     this.setState({showEmojiPicker: bool === false ? false : !this.state.showEmojiPicker})
   }
 
@@ -70,7 +85,6 @@ class LayoutScreen extends Component {
     }
 
     var onscroll = (event) => {
-      console.log("I got clicked")
       var node = event.target
       if (node.scrollHeight <= node.clientHeight + node.scrollTop) {
         self.shouldAutoScroll = true
@@ -81,8 +95,8 @@ class LayoutScreen extends Component {
 
     return (
       <div className='client'>
-        <CabalsList toggleEmojis={this.toggleEmoji}/>
-        <Sidebar toggleEmojis={this.toggleEmoji}/>
+        <CabalsList toggleEmojis={this.toggleEmoji} />
+        <Sidebar toggleEmojis={this.toggleEmoji} />
         <div className='client__main'>
           <div className='window'>
             <div className='window__header'>
@@ -107,7 +121,7 @@ class LayoutScreen extends Component {
                 toggleEmojis={this.toggleEmoji}
               />
             </div>
-            <WriteContainer showEmojiPicker={this.state.showEmojiPicker} toggleEmojis={this.toggleEmoji}/>
+            <WriteContainer showEmojiPicker={this.state.showEmojiPicker} toggleEmojis={this.toggleEmoji} />
           </div>
         </div>
       </div>

--- a/app/reducer.js
+++ b/app/reducer.js
@@ -15,7 +15,8 @@ const reducer = (state = defaultState, action) => {
     case 'CHANGE_SCREEN':
       return {
         ...state,
-        screen: action.screen
+        screen: action.screen,
+        addr: action.addr
       }
     case 'VIEW_CABAL':
       return {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ const template = [
     submenu: [
       {
         label: 'Learn More',
-        click () { require('electron').shell.openExternal('https://electronjs.org') }
+        click () { require('electron').shell.openExternal('https://cabal.chat') }
       }
     ]
   }
@@ -93,6 +93,8 @@ Menu.setApplicationMenu(menu)
 
 let win
 
+app.setAsDefaultProtocolClient('cabal')
+
 app.on('ready', () => {
   win = new BrowserWindow({
     width: 800,
@@ -109,6 +111,12 @@ app.on('ready', () => {
   win.webContents.on('will-navigate', (event, url) => {
     event.preventDefault()
     shell.openExternal(url)
+  })
+
+  // Protocol handler for osx
+  app.on('open-url', (event, url) => {
+    event.preventDefault()
+    win.webContents.send('open-cabal-url', {url})
   })
 })
 

--- a/package.json
+++ b/package.json
@@ -65,15 +65,15 @@
     "remark-emoji": "^2.0.1",
     "remark-react": "^4.0.3",
     "strftime": "^0.10.0",
-    "to2": "^1.0.0"    
+    "to2": "^1.0.0"
   },
   "build": {
     "appId": "club.cabal.desktop",
     "protocols": [
       {
-        "name": "Dat Link",
+        "name": "cabal",
         "schemes": [
-          "dat"
+          "cabal"
         ]
       }
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4198,8 +4198,8 @@ multifeed-index@^3.0.1:
     inherits "^2.0.3"
 
 multifeed@^1.3.3:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/multifeed/-/multifeed-1.3.8.tgz#f3026b3a4929f32aaff6421f3041a396d6fe3c81"
+  version "1.3.10"
+  resolved "https://registry.yarnpkg.com/multifeed/-/multifeed-1.3.10.tgz#1b738e228ccafce3a4a2135bce63e61ce62da10d"
   dependencies:
     duplexify "^3.6.0"
     hypercore-protocol "^6.6.4"


### PR DESCRIPTION
fixes #74

This adds the feature for clicking a cabal:// url which will open the app and either switch to that cabal or attempt to add it.