### PR TITLE
babel used in both dev and production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,6 @@
   "author": "Cabal Club",
   "license": "GPL-3.0",
   "devDependencies": {
-    "babel-core": "^6.26.0",
-    "babel-loader": "^7.1.2",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-env": "^1.6.1",
-    "babel-preset-react": "^6.24.1",
     "cross-env": "^5.2.0",
     "css-loader": "^1.0.0",
     "electron": "^3.0.0-beta.10",
@@ -36,6 +31,11 @@
     "webpack-node-externals": "^1.6.0"
   },
   "dependencies": {
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.2",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-preset-env": "^1.6.1",
+    "babel-preset-react": "^6.24.1",
     "cabal-core": "^3.0.2",
     "cat-names": "^1.0.2",
     "collect-stream": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -36,11 +36,6 @@
     "webpack-node-externals": "^1.6.0"
   },
   "dependencies": {
-    "babel-core": "^6.26.0",
-    "babel-loader": "^7.1.2",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-env": "^1.6.1",
-    "babel-preset-react": "^6.24.1",
     "cabal-core": "^3.0.2",
     "cat-names": "^1.0.2",
     "collect-stream": "^1.2.1",
@@ -65,7 +60,7 @@
     "remark-emoji": "^2.0.1",
     "remark-react": "^4.0.3",
     "strftime": "^0.10.0",
-    "to2": "^1.0.0"    
+    "to2": "^1.0.0"
   },
   "build": {
     "appId": "club.cabal.desktop",


### PR DESCRIPTION
Solves:

```
npm WARN The package babel-core is included as both a dev and production dependency.
npm WARN The package babel-loader is included as both a dev and production dependency.
npm WARN The package babel-plugin-transform-object-rest-spread is included as both a dev and production dependency.
npm WARN The package babel-preset-env is included as both a dev and production dependency.
npm WARN The package babel-preset-react is included as both a dev and production dependency.
```

Only used by `webpack` which is a devDependency, or am I missing something? :smile: 