### PR TITLE
fix username JSON serialization

### DIFF
--- a/app/actions.js
+++ b/app/actions.js
@@ -326,7 +326,7 @@ async function lskeys () {
 
 function encodeStateForKey (key) {
   const username = (cabals[key] && cabals[key].username) || DEFAULT_USERNAME
-  return `{"username":"${username}","addr":"${key}"}`
+  return JSON.stringify({"username":username,"addr":key})
 }
 
 async function readstate () {


### PR DESCRIPTION
Fix JSON serialization of username. 

In the existing build, if your username has a quotation mark in it, you can have a bad time.

![cabal_2018-11-17_17-04-53](https://user-images.githubusercontent.com/8461973/48666741-409b2d80-ea8d-11e8-8c23-c91c1de777e8.png)
