### PR TITLE
Add snapcraft builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
       "artifactName": "cabal-desktop-${version}-mac.${ext}"
     },
     "linux": {
-      "target": "AppImage",
+      "target": ["AppImage", "snap"],
       "category": "Network"
     },
     "appImage": {


### PR DESCRIPTION
Add "snap" as a target for the linux builds. Having issues on my end with ExperimentalWarning: The fs.promises API is experimental" and "Uncaught (in promise) Error: ENOENT: no such file or directory, mkdir '/home/rujak/.cabal-dekstop/v1'

Here is the build asciinema: https://asciinema.org/a/z8q8Y0QTByNqQIdEc3e8h16Fj