### PR TITLE
Fix #100 and create cabal's config dir

### DIFF
--- a/app/actions.js
+++ b/app/actions.js
@@ -319,7 +319,7 @@ async function lskeys () {
     list = filterForKeys(await readdir(DATA_DIR))
   } catch (_) {
     list = []
-    await mkdir(DATA_DIR)
+    await mkdir(DATA_DIR, {recursive: true})
   }
   return list
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "repository": "cabal-club/cabal-desktop",
   "author": "Cabal Club",
   "license": "GPL-3.0",
+  "engines" : { "node" : ">=10.12.0" },
   "devDependencies": {
     "cross-env": "^5.2.0",
     "css-loader": "^1.0.0",


### PR DESCRIPTION
- fixes #100 
- use the relatively new 'recursive' option on fs.mkDir so that it also creates the parent dir
- specify the new min node version in the package.json

Not sure how you feel about the node version requirement, but there are certainly other ways to do this that don't make use of the new recursive option.  (lots of packages do this or can implement it directly)