### PR TITLE
fix disabled share button

### DIFF
--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -397,6 +397,7 @@ form {
     color: rgba(0, 0, 0, 0.66);
     transition: all 0.075s ease-in-out;
     cursor: pointer;
+    -webkit-app-region: no-drag;
   }
 
   .channel-meta__other .channel-meta__other__share:hover {


### PR DESCRIPTION
the share button currently doesn't work (#94).
this is because it's in a draggable region: https://github.com/electron/electron/issues/741

you have to explicitly set it to non-draggable to enable clicks. this PR does just that.