### PR TITLE
enable window frame

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ app.on('ready', () => {
     height: 600,
     minWidth: 640,
     minHeight: 395,
-    frame: false,
+    frame: true,
     titleBarStyle: 'hidden'
   })
   win.maximize()


### PR DESCRIPTION
right now, you can't close the app on windows or linux.

i looked into adding a custom close button but since the app's UI might be changing (?) it seems simpler to just enable the default frame?