### PR TITLE
Render improvements for peers online

### DIFF
--- a/app/containers/sidebar.js
+++ b/app/containers/sidebar.js
@@ -140,10 +140,10 @@ class SidebarScreen extends React.Component {
                 <div key={user.key} className='collection__item'>
                   <div className='collection__item__icon'>
                     {!!user.online &&
-                      <img src='static/images/icon-status-online.svg' />
+                      <img alt="Online" src='static/images/icon-status-online.svg' />
                     }
                     {!user.online &&
-                      <img src='static/images/icon-status-offline.svg' />
+                      <img alt="Offline" src='static/images/icon-status-offline.svg' />
                     }
                   </div>
                   <div className='collection__item__content'>{user.name || user.key.substring(0, 6)}</div>

--- a/app/containers/sidebar.js
+++ b/app/containers/sidebar.js
@@ -87,11 +87,22 @@ class SidebarScreen extends React.Component {
     })
   }
 
+  sortUsers (users) {
+    return users.sort((a, b) => {
+      if (a.online && !b.online) return -1
+      if (b.online && !a.online) return 1
+      if (a.name && !b.name) return -1
+      if (b.name && !a.name) return 1
+      if (a.name && b.name) return a.name < b.name ? -1 : 1
+      return a.key < b.key ? -1 : 1
+    })
+  }
+
   render () {
     var self = this
     const { addr, cabal } = this.props
     let channels = cabal.channels
-    let users = Object.values(cabal.users) || []
+    let users = this.sortUsers(Object.values(cabal.users) || [])
     let username = cabal.username || 'conspirator'
     return (
       <div className='client__sidebar' onClick={(e) => this.props.toggleEmojis(false)}>
@@ -136,14 +147,14 @@ class SidebarScreen extends React.Component {
                 <div className='collection__heading__title'>Peers</div>
                 <div className='collection__heading__handle' />
               </div>
-              {this.sortByProperty(users).map((user) =>
+              {users.map((user) =>
                 <div key={user.key} className='collection__item'>
                   <div className='collection__item__icon'>
                     {!!user.online &&
-                      <img alt="Online" src='static/images/icon-status-online.svg' />
+                      <img alt='Online' src='static/images/icon-status-online.svg' />
                     }
                     {!user.online &&
-                      <img alt="Offline" src='static/images/icon-status-offline.svg' />
+                      <img alt='Offline' src='static/images/icon-status-offline.svg' />
                     }
                   </div>
                   {!!user.online &&

--- a/app/containers/sidebar.js
+++ b/app/containers/sidebar.js
@@ -93,7 +93,7 @@ class SidebarScreen extends React.Component {
       if (b.online && !a.online) return 1
       if (a.name && !b.name) return -1
       if (b.name && !a.name) return 1
-      if (a.name && b.name) return a.name < b.name ? -1 : 1
+      if (a.name && b.name) return a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1
       return a.key < b.key ? -1 : 1
     })
   }

--- a/app/containers/sidebar.js
+++ b/app/containers/sidebar.js
@@ -146,7 +146,12 @@ class SidebarScreen extends React.Component {
                       <img alt="Offline" src='static/images/icon-status-offline.svg' />
                     }
                   </div>
-                  <div className='collection__item__content'>{user.name || user.key.substring(0, 6)}</div>
+                  {!!user.online &&
+                    <div className='collection__item__content active'>{user.name || user.key.substring(0, 6)}</div>
+                  }
+                  {!user.online &&
+                    <div className='collection__item__content'>{user.name || user.key.substring(0, 6)}</div>
+                  }
                   <div className='collection__item__handle' />
                 </div>
               )}

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -175,7 +175,7 @@ form {
     flex-basis: 2rem;
   }
 
-  .session .session__avatar__img {}
+  // .session .session__avatar__img {}
 
   .session .session__avatar__img .identicon {
     width: 2rem;
@@ -459,8 +459,8 @@ form {
     margin-left: 0.125rem;
   }
 
-  .messages__item--emote {
-  }
+  // .messages__item--emote {
+  // }
 
   .messages__item--system {
     background: #f8f8f8;
@@ -610,7 +610,6 @@ form {
       border: 0;
       display: block;
       width: 100%;
-      vertical-align: middle;
       font-size: 0.875rem;
       outline: none;
       max-height: 200px; // this is a guess!?
@@ -620,7 +619,6 @@ form {
       border: 0;
       display: block;
       width: 100%;
-      vertical-align: middle;
       font-size: 0.875rem;
       outline: none;
     }

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -336,7 +336,8 @@ form {
   }
 
   /* States */
-  .collection .collection__item.active .collection__item__content {
+  .collection .collection__item.active .collection__item__content,
+  .collection .collection__item .collection__item__content.active {
     font-weight: 700;
     color: white;
   }

--- a/static/images/icon-status-offline.svg
+++ b/static/images/icon-status-offline.svg
@@ -1,13 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
-    <title>icon-status-online</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="icon-status-online" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g>
-            <circle id="Status" fill="#dddddd" cx="10" cy="10" r="2"></circle>
-            <rect id="Bounds" stroke-opacity="0" stroke="#979797" fill-opacity="0" fill="#D8D8D8" opacity="0" x="0" y="0" width="20" height="20"></rect>
-        </g>
-    </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#DDDDDD;}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#D8D8D8;fill-opacity:0;}
+</style>
+<title>icon-status-online</title>
+<desc>Created with Sketch.</desc>
+<g id="icon-status-online">
+	<g>
+		<circle id="Status" class="st0" cx="10" cy="10" r="4"/>
+		<rect id="Bounds" x="-10" y="-10" class="st1" width="40" height="40"/>
+	</g>
+</g>
 </svg>

--- a/static/images/icon-status-online.svg
+++ b/static/images/icon-status-online.svg
@@ -1,13 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
-    <title>icon-status-online</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="icon-status-online" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g>
-            <circle id="Status" fill="#0BE18A" cx="10" cy="10" r="2"></circle>
-            <rect id="Bounds" stroke-opacity="0" stroke="#979797" fill-opacity="0" fill="#D8D8D8" opacity="0" x="0" y="0" width="20" height="20"></rect>
-        </g>
-    </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#0BE18A;}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#D8D8D8;fill-opacity:0;}
+</style>
+<title>icon-status-online</title>
+<desc>Created with Sketch.</desc>
+<g id="icon-status-online">
+	<g>
+		<circle id="Status" class="st0" cx="10" cy="10" r="4"/>
+		<rect id="Bounds" x="-10" y="-10" class="st1" width="40" height="40"/>
+	</g>
+</g>
 </svg>


### PR DESCRIPTION
Still working through this, but here's where I'm at:

- [x] increased status icon size
- [x] added conditional styling (bold and white if online)
- [x] added `alt` text to icons (`Offline`, `Online`)
- [x] sort first by alphabetical+online status, then alphabetical+offline status

![Screen Shot 2019-06-20 at 10 09 44 AM](https://user-images.githubusercontent.com/158590/59864235-9695c380-9343-11e9-85cc-f75ec2dd28e1.png)

Help welcome, since I'm not sure how to write the sorting bit.