### PR TITLE
Add setting to toggle desktop notifications

### DIFF
--- a/app/containers/cabalSettings.js
+++ b/app/containers/cabalSettings.js
@@ -1,24 +1,32 @@
 import React from 'react'
 import { connect } from 'react-redux'
 
-import { hideCabalSettings, removeCabal } from '../actions'
+import { hideCabalSettings, removeCabal, saveCabalSettings } from '../actions'
 
 const mapStateToProps = state => {
   var cabal = state.cabals[state.currentCabal]
   return {
-    cabal
+    cabal,
+    settings: cabal.settings
   }
 }
 
 const mapDispatchToProps = dispatch => ({
   hideCabalSettings: () => dispatch(hideCabalSettings()),
-  removeCabal: ({ addr }) => dispatch(removeCabal({ addr }))
+  removeCabal: ({ addr }) => dispatch(removeCabal({ addr })),
+  saveCabalSettings: ({ addr, settings }) => dispatch(saveCabalSettings({ addr, settings }))
 })
 
 class CabalSettingsContainer extends React.Component {
 
   onClickCloseSettings () {
     this.props.hideCabalSettings()
+  }
+
+  onToggleOption (option) {
+    let settings = this.props.settings
+    settings[option] = !this.props.settings[option]
+    this.props.saveCabalSettings({ addr: this.props.cabal.addr, settings })
   }
 
   removeCabal (addr) {
@@ -43,14 +51,35 @@ class CabalSettingsContainer extends React.Component {
           </div>
           <div className='window__main'>
             <div className='window__main__content'>
-              <ul>
-                <li>
-                  <strong>Cabal Key:</strong> cabal://{this.props.cabal.addr}
-                </li>
-                <li>
-                  <button className='button' onClick={this.removeCabal.bind(this, this.props.cabal.addr)}>Remove this cabal from Cabal Desktop</button>
-                </li>
-              </ul>
+              <div className='cabal-settings__item' onClick={this.onToggleOption.bind(this, 'enableNotifications')}>
+                <div className='cabal-settings__item-row'>
+                  <div className='cabal-settings__item-checkbox'>
+                    <input type='checkbox' checked={!!this.props.settings.enableNotifications} onChange={() => {}} />
+                  </div>
+                  <div className='cabal-settings__item-label'>
+                    <div className='cabal-settings__item-label-title'>Enable desktop notifications</div>
+                    <div className='cabal-settings__item-label-description'>Display a notification for new messages for this cabal when a channel is in the background.</div>
+                  </div>
+                </div>
+              </div>
+              <div className='cabal-settings__item'>
+                <div className='cabal-settings__item-label'>
+                  <div className='cabal-settings__item-label-title'>Cabal Key</div>
+                  <div className='cabal-settings__item-label-description'>Share this key with others to let them join the cabal.</div>
+                </div>
+                <div className='cabal-settings__item-input'>
+                  <input type='text' value={`cabal://${this.props.cabal.addr}`} />
+                </div>
+              </div>
+              <div className='cabal-settings__item'>
+                <div className='cabal-settings__item-label'>
+                  <div className='cabal-settings__item-label-title'>Remove this cabal from this Cabal Desktop client</div>
+                  <div className='cabal-settings__item-label-description'>The local cabal database will remain and may also exist on peer clients.</div>
+                </div>
+                <div className='cabal-settings__item-input'>
+                  <button className='button' onClick={this.removeCabal.bind(this, this.props.cabal.addr)}>Remove Cabal ({this.props.cabal.addr.substr(0, 8)}...)</button>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -609,6 +609,40 @@ form {
     cursor: pointer;
   }
 
+  .cabal-settings__item {
+    margin-bottom: 2rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid #eee;
+  }
+
+  .cabal-settings__item-row {
+    display: flex;
+    align-items: center;
+  }
+
+  .cabal-settings__item-checkbox input[type=checkbox] {
+    width: 2rem;
+    height: 2rem;
+    cursor: pointer;
+  }
+
+  .cabal-settings__item-label-title {
+    font-weight: 700;
+    margin-bottom: 0.4rem;
+  }
+
+  .cabal-settings__item-label-description {
+    color: #303030;
+  }
+
+  .cabal-settings__item-input {
+    margin-top: 1rem;
+  }
+
+  .cabal-settings__item-input input {
+    width: 100%;
+  }
+
   .composerContainer {
     margin: 0 1rem 1rem 1rem;
     cursor: text;


### PR DESCRIPTION
desktop notifications will now be disabled by default. Users may opt in to notifications from the cabal settings screen.

fixes #71

<img width="952" alt="Screen Shot 2019-07-13 at 11 50 05 PM" src="https://user-images.githubusercontent.com/40796/61179107-c42ffe80-a5c9-11e9-9769-6490b01c793c.png">
