### PR TITLE
Keep app running when window is closed on MacOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,6 +147,25 @@ app.on('ready', () => {
       app.setBadgeCount(badgeCount)
     }
   })
+
+  win.on('close', event => {
+    if (!app.quitting) {
+      event.preventDefault()
+      win.hide()
+    }
+  })
+
+  app.on('activate', () => {
+    win.show()
+  })
 })
 
-app.on('window-all-closed', () => app.quit())
+app.on('window-all-closed', () => {
+  if (os.platform() !== 'darwin') {
+    app.quit()
+  }
+})
+
+app.on('before-quit', () => {
+  app.quitting = true
+})


### PR DESCRIPTION
Mimics the behavior from other messaging apps, such as Slack and Patchwork on MacOS. Closing a window will not quit the app, but hides the window instead. Clicking the dock icon will show the window. Cmd-Q will quit the app.