### PR TITLE
fix: remove resize arrow from textarea

### DIFF
--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -725,6 +725,7 @@ form {
       font-size: 0.875rem;
       outline: none;
       max-height: 200px; // this is a guess!?
+      resize: none;
     }
 
     .composer__input input {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2119706/72565762-5377e080-3891-11ea-86d8-b1fd1482eac1.png)
