### PR TITLE
fix: upgrade to cabal-client@6.0.0 to get new swarm fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@babel/runtime": "^7.7.7",
     "@reduxjs/toolkit": "^1.3.5",
     "babel-runtime": "^6.26.0",
-    "cabal-client": "^5.1.1",
+    "cabal-client": "^6.0.0",
     "collect-stream": "^1.2.1",
     "dat-encoding": "^5.0.1",
     "debug": "^4.1.1",


### PR DESCRIPTION
This is a breaking change, but allows direct peer-to-peer connections. Woohoo!