### PR TITLE
feat: check for new cabal updates when online and install them automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,26 @@ tiffutil -cathidpicheck cabal-desktop-dmg-background.jpg cabal-desktop-dmg-backg
 
 ## Distribute
 
-build for current platform:
+TravisCI will automatically create and upload the appropriate release packages
+for you when you're ready to release. Here's the process for distributing 
+production builds.
+
+1. Draft a new release. Set the “Tag version” to the value of version in your
+application package.json, and prefix it with v. “Release title” can be anything
+you want. For example, if your application package.json version is 1.0, your draft’s
+“Tag version” would be v1.0.
+
+2. Push some commits. Every CI build will update the artifacts attached to this
+   draft.
+
+3. Once you are done, create the tag (e.g., `git tag v6.0.0`) and publish the release (`git push --tags && npm publish`). GitHub will tag
+   the latest commit for you.
+
+The benefit of this workflow is that it allows you to always have the latest
+artifacts, and the release can be published once it is ready.
+
+
+Build for current platform:
 
 ```
 $ yarn run dist

--- a/app/settings.js
+++ b/app/settings.js
@@ -1,0 +1,13 @@
+const Store = require('electron-store')
+
+const store = new Store({ name: 'cabal-desktop-settings' })
+const store_defaults = {
+  'auto-update': true
+}
+
+for (var key in store_defaults) {
+  if (store.get(key) === undefined) store.set(key, store_defaults[key])
+}
+
+module.exports = store
+

--- a/app/updater.js
+++ b/app/updater.js
@@ -1,0 +1,24 @@
+const { autoUpdater } = require('electron-updater')
+
+class AutoUpdater {
+  constructor () {
+    this.interval = false
+  }
+
+  start () {
+    const FOUR_HOURS = 60 * 60 * 1000
+    try {
+      this.interval = setInterval(() => autoUpdater.checkForUpdatesAndNotify(), FOUR_HOURS)
+      autoUpdater.checkForUpdatesAndNotify()
+    } catch (err) {
+      // If offline, the auto updater will throw an error.
+      console.error(err)
+    }
+  }
+
+  stop () {
+    clearInterval(this.interval)
+  }
+}
+
+module.exports = AutoUpdater

--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 'use strict'
 
 const { app, BrowserWindow, shell, Menu, ipcMain } = require('electron')
+const isDev = require('electron-is-dev')
 const windowStateKeeper = require('electron-window-state')
 const os = require('os')
 const path = require('path')
+const { autoUpdater } = require('electron-updater')
 
-if (process.env.NODE_ENV === 'development') {
+if (isDev) {
   require('electron-reload')(__dirname, {
     electron: path.join(__dirname, 'node_modules', '.bin', 'electron'),
     hardResetMethod: 'exit'
@@ -114,6 +116,7 @@ app.on('second-instance', (event, argv, cwd) => {
 app.setAsDefaultProtocolClient('cabal')
 
 app.on('ready', () => {
+  if (!isDev) startAutoUpdater() 
   const mainWindowState = windowStateKeeper({
     defaultWidth: 800,
     defaultHeight: 600
@@ -180,3 +183,15 @@ app.on('window-all-closed', () => {
 app.on('before-quit', () => {
   app.quitting = true
 })
+
+
+function startAutoUpdater () {
+  const FOUR_HOURS = 60 * 60 * 1000
+  try {
+    setInterval(() => autoUpdater.checkForUpdatesAndNotify(), FOUR_HOURS)
+    autoUpdater.checkForUpdatesAndNotify()
+  } catch (err) {
+    // If offline, the auto updater will throw an error.
+    console.error(err)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "watch": "webpack --watch",
     "start": "cross-env NODE_ENV=development npm-run-all --parallel start:*",
     "pack": "electron-builder --dir",
-    "dist": "yarn run build && electron-builder",
+    "dist": "yarn run build && electron-builder --publish=onTagOrDraft",
     "dist:multi": "electron-builder -mlw",
     "postinstall": "electron-builder install-app-deps",
     "test": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 jest --passWithNoTests"
@@ -57,8 +57,10 @@
     "debug": "^4.1.1",
     "del": "^5.1.0",
     "electron-default-menu": "^1.0.1",
+    "electron-is-dev": "^1.2.0",
     "electron-prompt": "^1.5.1",
     "electron-reload": "^1.5.0",
+    "electron-updater": "^4.3.1",
     "electron-window-state": "^5.0.3",
     "emoji-mart": "^3.0.0",
     "get-form-data": "^3.0.0",
@@ -86,6 +88,9 @@
     "appId": "club.cabal.desktop",
     "afterSign": "scripts/notarize.js",
     "productName": "Cabal",
+    "publish": [
+      "github"
+    ],
     "protocols": [
       {
         "name": "cabal",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,23 @@
     },
     "nsis": {
       "artifactName": "cabal-desktop-${version}-windows.${ext}"
-    }
+    },
+    "files": [
+      "**/*",
+      "!**/node_modules/pannellum/*.{jpg,png}",
+      "!**/node_modules/sodium-native/prebuilds/linux-arm",
+      "!**/node_modules/*/{CHANGELOG.md,README.md,README,readme.md,readme}",
+      "!**/node_modules/**/{test,__tests__,tests,powered-test,example,examples}",
+      "!**/node_modules/.bin",
+      "!**/*.{iml,o,hprof,orig,pyc,pyo,rbc,swp,csproj,sln,xproj}",
+      "!.editorconfig",
+      "!**/._*",
+      "!**/{.DS_Store,.git,.hg,.svn,CVS,RCS,SCCS,.gitignore,.gitattributes}",
+      "!**/{__pycache__,thumbs.db,.flowconfig,.idea,.vs,.nyc_output}",
+      "!**/{appveyor.yml,.travis.yml,circle.yml}",
+      "!**/{npm-debug.log,yarn.lock,.yarn-integrity,.yarn-metadata.json}",
+      "!test${/*}"
+    ]
   },
   "np": {
     "yarn": false,

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "electron-is-dev": "^1.2.0",
     "electron-prompt": "^1.5.1",
     "electron-reload": "^1.5.0",
+    "electron-store": "^5.2.0",
     "electron-updater": "^4.3.1",
     "electron-window-state": "^5.0.3",
     "emoji-mart": "^3.0.0",


### PR DESCRIPTION
This should also upload the proper `latest.yml` files to the github releases page.

Right now it is opt-out, because with the amount of new releases and critical bugfixes coming through, I think it is ideal to keep people up-to-date with cabal's swift movement!