### PR TITLE
fix: defensive programming for cabalDetails.getUsers() function

### DIFF
--- a/app/containers/channelPanel.js
+++ b/app/containers/channelPanel.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { connect } from 'react-redux'
 
 import {
-  getUsers,
   hideChannelPanel,
   leaveChannel,
   moderationAddAdmin,
@@ -14,7 +13,6 @@ import {
   moderationUnblock,
   moderationUnhide
 } from '../actions'
-import Avatar from './avatar'
 import MemberList from './memberList'
 
 const mapStateToProps = state => ({
@@ -23,7 +21,6 @@ const mapStateToProps = state => ({
 })
 
 const mapDispatchToProps = dispatch => ({
-  getUsers: ({ addr }) => dispatch(getUsers({ addr })),
   hideChannelPanel: ({ addr }) => dispatch(hideChannelPanel({ addr })),
   leaveChannel: ({ addr, channel }) => dispatch(leaveChannel({ addr, channel })),
   moderationAddAdmin: ({ addr, channel, reason, userKey }) => dispatch(moderationAddAdmin({ addr, channel, reason, userKey })),
@@ -37,8 +34,6 @@ const mapDispatchToProps = dispatch => ({
 })
 
 function ChannelPanel (props) {
-  const user = props.getUsers({ addr: props.addr })[props.userKey]
-
   function onClickLeaveChannel () {
     props.leaveChannel({
       addr: props.cabal.addr,

--- a/app/containers/messages.js
+++ b/app/containers/messages.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux'
 import moment from 'moment'
 
 import {
-  getUsers,
+  getUser,
   showProfilePanel
 } from '../actions'
 import Avatar from './avatar'
@@ -14,7 +14,7 @@ const mapStateToProps = state => ({
 })
 
 const mapDispatchToProps = dispatch => ({
-  getUsers: ({ addr }) => dispatch(getUsers({ addr })),
+  getUser: ({ key }) => dispatch(getUser({ key })),
   showProfilePanel: ({ addr, userKey }) => dispatch(showProfilePanel({ addr, userKey }))
 })
 
@@ -50,8 +50,8 @@ function MessagesContainer (props) {
     return (
       <div className='messages'>
         {messages.map((message) => {
-          const user = props.getUsers({ addr: props.addr })[message.key]
           // Hide messages from hidden users
+          const user = message.user
           if (user && user.isHidden()) return null
 
           const enriched = message.enriched
@@ -88,8 +88,8 @@ function MessagesContainer (props) {
           }
           if (message.type === 'chat/moderation') {
             const { role, type, issuerid, receiverid, reason } = message.content
-            const issuer = props.getUsers({ addr: props.addr })[issuerid]
-            const receiver = props.getUsers({ addr: props.addr })[receiverid]
+            const issuer = props.getUser({ key: issuerid })
+            const receiver = props.getUser({ key: receiverid })
             const issuerName = issuer && issuer.name ? issuer.name : issuerid.slice(0, 8)
             const receiverName = receiver && receiver.name ? receiver.name : receiverid.slice(0, 8)
             item = (
@@ -124,7 +124,7 @@ function MessagesContainer (props) {
                 <div className='messages__item__metadata'>
                   {!repeatedAuthor &&
                     <div onClick={onClickProfile.bind(this, user)} className='messages__item__metadata__name'>
-                      {message.author || message.key.substr(0, 6)}
+                      {user.name}
                       {user.isAdmin() && <span className='sigil admin' title='Admin'>@</span>}
                       {user.isModerator() && <span className='sigil moderator' title='Moderator'>%</span>}
                       {renderDate(formattedTime)}
@@ -145,7 +145,7 @@ function MessagesContainer (props) {
                   </div>
                 </div>
                 <div className='messages__item__metadata'>
-                  {repeatedAuthor ? null : <div onClick={onClickProfile.bind(this, user)} className='messages__item__metadata__name'>{message.author}{renderDate(formattedTime)}</div>}
+                  {repeatedAuthor ? null : <div onClick={onClickProfile.bind(this, user)} className='messages__item__metadata__name'>{user.name}{renderDate(formattedTime)}</div>}
                   <div className={repeatedAuthor ? 'text indent' : 'text'}>{enriched.content}</div>
                 </div>
               </div>

--- a/app/containers/profilePanel.js
+++ b/app/containers/profilePanel.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 
 import {
-  getUsers,
+  getUser,
   hideProfilePanel,
   moderationAddAdmin,
   moderationAddMod,
@@ -21,7 +21,7 @@ const mapStateToProps = state => ({
 })
 
 const mapDispatchToProps = dispatch => ({
-  getUsers: ({ addr }) => dispatch(getUsers({ addr })),
+  getUser: ({ key }) => dispatch(getUser({ key })),
   hideProfilePanel: ({ addr }) => dispatch(hideProfilePanel({ addr })),
   moderationAddAdmin: ({ addr, channel, reason, userKey }) => dispatch(moderationAddAdmin({ addr, channel, reason, userKey })),
   moderationAddMod: ({ addr, channel, reason, userKey }) => dispatch(moderationAddMod({ addr, channel, reason, userKey })),
@@ -34,7 +34,7 @@ const mapDispatchToProps = dispatch => ({
 })
 
 function ProfilePanel (props) {
-  const user = props.getUsers({ addr: props.addr })[props.userKey]
+  const user = props.getUser({ key: props.userKey })
 
   function onClickHideUserAll () {
     props.moderationHide({


### PR DESCRIPTION
Hey all,

This fixes #268 #264 , maybe other recent GitHub issues. This happened due to malformed data on the network sent from someone's cabal instance.

Practically, (beyond the scope of this particular defensive PR), getUser ought to  be a function implemented internally inside cabalDetails. cabalDetails ought to also use this getUser function internally instead of `()[]` which is extremely fragile, and supply a default user if that user is malformed. I didn't have time to also do a PR there, though. 

Overall, a single peer sending malformed data should not mess up everyone else's clients. Some more defensiveness lower in the stack (cabal-core/client) will become even more crucial as more people decide to write their own clients (!good thing!) and also make it easier to write new clients in other languages as well as bridges to other networks (e.g., matrix, irc) if you know what fields each message type should have (Woo lets have more impl.!)
            



