### PR TITLE
feat: try to sync newly added cabals before listening to events

### DIFF
--- a/app/containers/addCabal.js
+++ b/app/containers/addCabal.js
@@ -5,7 +5,7 @@ import { addCabal } from '../actions'
 const mapStateToProps = state => state
 
 const mapDispatchToProps = dispatch => ({
-  addCabal: ({ addr, username }) => dispatch(addCabal({ addr, username })),
+  addCabal: ({ addr, isNewlyAdded, username }) => dispatch(addCabal({ addr, isNewlyAdded, username })),
   newCabal: (username) => dispatch(addCabal({ username })),
   hide: () => dispatch({ type: 'CHANGE_SCREEN', screen: 'main' })
 })
@@ -26,6 +26,7 @@ class addCabalScreen extends Component {
     if (cabal.value) {
       this.props.addCabal({
         addr: cabal.value,
+        isNewlyAdded: true,
         username: nickname.value
       })
       this.props.hide()

--- a/app/containers/layout.js
+++ b/app/containers/layout.js
@@ -57,9 +57,7 @@ class LayoutScreen extends Component {
   render () {
     const { cabal, cabals, addr } = this.props
     const { enableDarkmode } = this.props.settings || {}
-    // console.log('render', { cabal, cabals, addr })
-    // if (!cabal || !this.cabalsInitialized()) {
-    if (!cabal) {
+    if (!cabal || !this.cabalsInitialized()) {
       return (
         <div className='loading'>
           <div className='status'> </div>

--- a/app/containers/sidebar.js
+++ b/app/containers/sidebar.js
@@ -181,8 +181,8 @@ class SidebarScreen extends React.Component {
     const deduplicatedNicks = []
     users && users.forEach((user) => {
       const userIndex = deduplicatedNicks.findIndex((u) => u.name === user.name)
-      const moderated = user.isHidden || user.isAdmin || user.isModerator
-      if (user.name && userIndex > -1 && !moderated) {
+      const moderated = user.isHidden() || user.isAdmin() || user.isModerator()
+      if (user.name && !moderated && userIndex > -1) {
         deduplicatedNicks[userIndex].users.push(user)
       } else {
         deduplicatedNicks.push({

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@babel/runtime": "^7.7.7",
     "@reduxjs/toolkit": "^1.3.5",
     "babel-runtime": "^6.26.0",
-    "cabal-client": "6.1.0",
+    "cabal-client": "6.1.2",
     "collect-stream": "^1.2.1",
     "dat-encoding": "^5.0.1",
     "debug": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2359,10 +2359,10 @@ bulk-write-stream@^1.1.3:
     inherits "^2.0.1"
     readable-stream "^2.1.4"
 
-cabal-client@6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/cabal-client/-/cabal-client-6.1.0.tgz#5e350c836d5c46bbf55ef032897ed8dd948531e7"
-  integrity sha512-y/8CJBR4+f8MIdwXCfKevYzkV7Jdnb19WDixFValn6U180zKIA4dWkoWaD0B1Kr9PNy2bKLT1/ixG2Tsn76e/g==
+cabal-client@6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/cabal-client/-/cabal-client-6.1.2.tgz#ceca6343317baa313d7e9763c115032a48f7200d"
+  integrity sha512-jHr4PFoVb99RNoxWWuYK6tq3yo6suizFXb+c4CWx5gJCQ5qQran8VYMCp+SKwbUX22ESMoU+4wVokBirX4xrHg==
   dependencies:
     cabal-core "^13.0.0"
     collect-stream "^1.2.1"
@@ -2380,9 +2380,9 @@ cabal-client@6.1.0:
     to2 "^1.0.0"
 
 cabal-core@^13.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/cabal-core/-/cabal-core-13.0.0.tgz#b2315075b083f3d28f0b3a8425b8861302aff48f"
-  integrity sha512-R+aeOtpcuseDRYuqBXUJO2MCwLTupxax3EPXR1XcaqKSqlTxgQRtt7NVT93+qJH8HYzDH8H3O/poDvEaSZLT3Q==
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/cabal-core/-/cabal-core-13.0.1.tgz#f5ca90bb4e87d063550ae9cf26b6a112421cf466"
+  integrity sha512-pTnRl2j0WfX4+ol3BAcCa+OjSxZHs7ie3JACc4oyjTQL+wNAV5N1h4NNS1uc6cnGI5oOCHd6OkF0OG/icMeuzw==
   dependencies:
     charwise "^3.0.1"
     collect-stream "^1.2.1"
@@ -5205,7 +5205,12 @@ ignore@^5.0.0, ignore@^5.1.1:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
-immediate@^3.2.3, immediate@~3.2.3:
+immediate@^3.2.3:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.3.0.tgz#1aef225517836bcdf7f2a2de2600c79ff0269266"
+  integrity sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==
+
+immediate@~3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
   integrity sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=
@@ -8643,9 +8648,9 @@ qs@~6.5.2:
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
 query-string@^6.8.2:
-  version "6.12.1"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.12.1.tgz#2ae4d272db4fba267141665374e49a1de09e8a7c"
-  integrity sha512-OHj+zzfRMyj3rmo/6G8a5Ifvw3AleL/EbcHMD27YA31Q+cO5lfmQxECkImuNVjcskLcvBRVHNAB3w6udMs1eAA==
+  version "6.13.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.1.tgz#d913ccfce3b4b3a713989fe6d39466d92e71ccad"
+  integrity sha512-RfoButmcK+yCta1+FuU8REvisx1oEzhMKwhLUNcepQTPGcNMp1sIqjnfCtfnvGSQZQEhaBHvccujtWoUV3TTbA==
   dependencies:
     decode-uri-component "^0.2.0"
     split-on-first "^1.0.0"
@@ -10022,9 +10027,9 @@ stream-shift@^1.0.0:
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
 
 streamx@^2.1.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.6.0.tgz#f7aa741edc8142666c12d09479e708fdc2a09c33"
-  integrity sha512-fDIdCkmCjhNt9/IIFL6UdJeqyOpDoX9rHXdRt5hpYQQ1owCSyVieQtTkbXcZAsASS9F5JrlxwKLHkv5w2GHVvA==
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.6.3.tgz#0331675a9c96211e9cc226b622cf21a0732e83d5"
+  integrity sha512-GF1TU5hNN0EabSgEoGGSzxwQ7ah+cp8YC1S8c9j3xizy55DHfu7xh0mbXw2w55EABfx38MNfz8oN3ldw6RxN2Q==
   dependencies:
     fast-fifo "^1.0.0"
     nanoassert "^2.0.0"


### PR DESCRIPTION
By waiting for a few seconds before listening to cabal-client events, the db can have time to sync with peers without the client being overwhelmed with the flood of past events.

Here's a gif of an empty db loading the current public cabal:

![2020-06-12 22 18 03](https://user-images.githubusercontent.com/40796/84557744-8cf72f80-acfb-11ea-996a-9d7e329828d6.gif)

previously, loading the public cabal resulted in minutes of waiting and often required a few restarts or crashes to get through this initial sync.
