### PR TITLE
fix: ensure users always have a .name property

### DIFF
--- a/app/actions.js
+++ b/app/actions.js
@@ -307,10 +307,14 @@ export const getUser = ({ key }) => (dispatch) => {
   const cabalDetails = client.getCurrentCabal()
   const users = cabalDetails.getUsers()
   // TODO: This should be inside cabalDetails.getUser(...)
-  return users[key] ? users[key] : new User({
+  var user = users[key]
+  if (!user) user = new User({
     name: key.substr(0, 6),
     key: key
   })
+  if (!user.name) user.name = key.substr(0,6)
+
+  return user
 }
 
 export const viewChannel = ({ addr, channel, skipScreenHistory }) => (dispatch, getState) => {
@@ -691,7 +695,7 @@ const initializeCabal = ({ addr, isNewlyAdded, username, settings }) => async di
       }, event.throttleDelay, { leading: true, trailing: true })
       cabalDetails.on(event.name, action)
     })
-    
+
     initialize()
     dispatch({ type: 'UPDATE_CABAL', initialized: true, addr })
   }, isNewlyAdded ? 10000 : 0)

--- a/app/actions.js
+++ b/app/actions.js
@@ -240,11 +240,12 @@ export const getMessages = ({ addr, channel, amount }, callback) => dispatch => 
         const user = dispatch(getUser({ key: message.key }))
         const { type, timestamp, content } = message.value
         return enrichMessage({
-          user: user,
           content: content && content.text,
           key: message.key,
+          message,
           time: timestamp,
-          type
+          type,
+          user
         })
       })
       dispatch({ type: 'UPDATE_CABAL', addr, messages })
@@ -271,11 +272,12 @@ export const onIncomingMessage = ({ addr, channel, message }, callback) => (disp
   if ((channel === currentChannel) && (addr === client.getCurrentCabal().key)) {
     const { type, timestamp, content } = message.value
     const enrichedMessage = enrichMessage({
-      user,
       content: content && content.text,
       key: message.key,
+      message,
       time: timestamp,
-      type
+      type,
+      user
     })
     const messages = [
       ...getState()?.cabals[addr].messages,
@@ -421,11 +423,12 @@ export const addChannel = ({ addr, channel }) => (dispatch, getState) => {
       }
 
       return enrichMessage({
-        user,
         content: content.text,
         key: message.key,
+        message,
         time: timestamp,
-        type
+        type,
+        user
       })
     })
     if (cabalDetails.getCurrentChannel() === channel) {

--- a/app/containers/messages.js
+++ b/app/containers/messages.js
@@ -87,7 +87,7 @@ function MessagesContainer (props) {
             )
           }
           if (message.type === 'chat/moderation') {
-            const { role, type, issuerid, receiverid, reason } = message.content
+            const { role, type, issuerid, receiverid, reason } = message.message.value.content
             const issuer = props.getUser({ key: issuerid })
             const receiver = props.getUser({ key: receiverid })
             const issuerName = issuer && issuer.name ? issuer.name : issuerid.slice(0, 8)
@@ -102,14 +102,16 @@ function MessagesContainer (props) {
                 <div className='messages__item__metadata'>
                   <div className='messages__item__metadata__name'>{message.name || defaultSystemName}{renderDate(formattedTime)}</div>
                   <div className='text'>
-                    Moderation:
                     {role === 'hide' &&
-                      <span><span onClick={onClickProfile.bind(this, issuer)}>{issuerName}</span> {(type === 'add' ? 'hid' : 'unhid')} <span onClick={onClickProfile.bind(this, receiver)}>{receiverName}</span></span>}
+                      <div>
+                        <a className='name' onClick={onClickProfile.bind(this, issuer)}>{issuerName}</a> {(type === 'add' ? 'hid' : 'unhid')} <a className='name' onClick={onClickProfile.bind(this, receiver)}>{receiverName}</a>
+                      </div>}
                     {role !== 'hide' &&
-                      <span><span onClick={onClickProfile.bind(this, issuer)}>{issuerName}</span> {(type === 'add' ? 'added' : 'removed')} <span onClick={onClickProfile.bind(this, receiver)}>{receiverName}</span> as {role}</span>}
+                      <div>
+                        <a className='name' onClick={onClickProfile.bind(this, issuer)}>{issuerName}</a> {(type === 'add' ? 'added' : 'removed')} <a className='name' onClick={onClickProfile.bind(this, receiver)}>{receiverName}</a> as {role}
+                      </div>}
                     {!!reason &&
-                      <span>({reason})</span>
-                    }
+                      <div>({reason})</div>}
                   </div>
                 </div>
               </div>

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -712,6 +712,11 @@ form {
     padding: 0 1.5rem 0 0;
     font-size: 0.875rem;
     line-height: 1.5;
+
+    .name {
+      cursor: pointer;
+      text-decoration: underline;
+    }
   }
 
   .messages__item__metadata .text.indent {


### PR DESCRIPTION
This would sometimes cause the JavaScript client to throw an exception and crash the desktop frontend