### PR TITLE
write selectors for layout

### DIFF
--- a/app/containers/channelPanel.js
+++ b/app/containers/channelPanel.js
@@ -3,52 +3,36 @@ import { connect } from 'react-redux'
 
 import {
   hideChannelPanel,
-  leaveChannel,
-  moderationAddAdmin,
-  moderationAddMod,
-  moderationBlock,
-  moderationHide,
-  moderationRemoveAdmin,
-  moderationRemoveMod,
-  moderationUnblock,
-  moderationUnhide
+  leaveChannel
 } from '../actions'
 import MemberList from './memberList'
 
 const mapStateToProps = state => ({
   addr: state.currentCabal,
-  cabal: state.cabals[state.currentCabal]
+  currentChannel: state.cabals[state.currentCabal].channel || ''
 })
 
 const mapDispatchToProps = dispatch => ({
   hideChannelPanel: ({ addr }) => dispatch(hideChannelPanel({ addr })),
-  leaveChannel: ({ addr, channel }) => dispatch(leaveChannel({ addr, channel })),
-  moderationAddAdmin: ({ addr, channel, reason, userKey }) => dispatch(moderationAddAdmin({ addr, channel, reason, userKey })),
-  moderationAddMod: ({ addr, channel, reason, userKey }) => dispatch(moderationAddMod({ addr, channel, reason, userKey })),
-  moderationBlock: ({ addr, channel, reason, userKey }) => dispatch(moderationBlock({ addr, channel, reason, userKey })),
-  moderationHide: ({ addr, channel, reason, userKey }) => dispatch(moderationHide({ addr, channel, reason, userKey })),
-  moderationRemoveAdmin: ({ addr, channel, reason, userKey }) => dispatch(moderationRemoveAdmin({ addr, channel, reason, userKey })),
-  moderationRemoveMod: ({ addr, channel, reason, userKey }) => dispatch(moderationRemoveMod({ addr, channel, reason, userKey })),
-  moderationUnblock: ({ addr, channel, reason, userKey }) => dispatch(moderationUnblock({ addr, channel, reason, userKey })),
-  moderationUnhide: ({ addr, channel, reason, userKey }) => dispatch(moderationUnhide({ addr, channel, reason, userKey }))
+  leaveChannel: ({ addr, channel }) => dispatch(leaveChannel({ addr, channel }))
 })
 
-function ChannelPanel (props) {
+function ChannelPanel ({ currentChannel, addr, hideChannelPanel, leaveChannel }) {
   function onClickLeaveChannel () {
-    props.leaveChannel({
-      addr: props.cabal.addr,
-      channel: props.cabal.channel
+    leaveChannel({
+      addr,
+      channel: currentChannel
     })
   }
 
-  const canLeave = props.cabal.channel !== '!status'
-  const hasMembers = props.cabal.channel !== '!status'
+  const canLeave = currentChannel !== '!status' && !!currentChannel
+  const hasMembers = currentChannel !== '!status'
 
   return (
     <div className='panel ChannelPanel'>
       <div className='panel__header'>
         Channel Details
-        <span onClick={() => props.hideChannelPanel({ addr: props.addr })} className='close'><img src='static/images/icon-composermeta.svg' /></span>
+        <span onClick={() => hideChannelPanel({ addr })} className='close'><img src='static/images/icon-composermeta.svg' /></span>
       </div>
       {canLeave &&
         <div className='panel__content'>
@@ -64,7 +48,7 @@ function ChannelPanel (props) {
             Channel Members
           </div>
           <div className='panel__content'>
-            <MemberList addr={props.addr} />
+            <MemberList addr={addr} />
           </div>
         </>}
     </div>

--- a/app/containers/layout.js
+++ b/app/containers/layout.js
@@ -10,17 +10,16 @@ import ChannelPanel from './channelPanel'
 import MainPanel from './mainPanel'
 import ProfilePanel from './profilePanel'
 import Sidebar from './sidebar'
+import { cabalSettingsSelector, isCabalsInitializedSelector } from '../selectors'
 
 const mapStateToProps = state => {
-  const cabal = state.cabals[state.currentCabal]
   return {
     addr: state.currentCabal,
-    cabal,
-    cabals: state.cabals,
+    cabalInitialized: isCabalsInitializedSelector(state),
     channelPanelVisible: state.channelPanelVisible[state.currentCabal],
     profilePanelVisible: state.profilePanelVisible[state.currentCabal],
     profilePanelUser: state.profilePanelUser[state.currentCabal],
-    settings: state.cabalSettings[cabal?.addr] || {}
+    settings: cabalSettingsSelector(state)
   }
 }
 
@@ -55,9 +54,8 @@ class LayoutScreen extends Component {
   }
 
   render () {
-    const { cabal, cabals, addr } = this.props
     const { enableDarkmode } = this.props.settings || {}
-    if (!cabal || !this.cabalsInitialized()) {
+    if (!this.props.cabalInitialized) {
       return (
         <div className='loading'>
           <div className='status'> </div>
@@ -66,6 +64,7 @@ class LayoutScreen extends Component {
         </div>
       )
     }
+
     return (
       <div className={`client ${enableDarkmode ? 'darkmode' : ''}`}>
         <CabalsList />

--- a/app/containers/layout.js
+++ b/app/containers/layout.js
@@ -29,7 +29,7 @@ const mapDispatchToProps = dispatch => ({
 })
 
 class LayoutScreen extends Component {
-  constructor (props) {
+  constructor(props) {
     super(props)
     this.state = {
       showMemberList: false
@@ -37,13 +37,13 @@ class LayoutScreen extends Component {
     this.toggleMemberList = this.toggleMemberList.bind(this)
   }
 
-  toggleMemberList () {
+  toggleMemberList() {
     this.setState((state) => ({
       showMemberList: !state.showMemberList
     }))
   }
 
-  render () {
+  render() {
     const { enableDarkmode } = this.props.settings || {}
     if (!this.props.cabalInitialized) {
       return (
@@ -60,7 +60,7 @@ class LayoutScreen extends Component {
         <CabalsList />
         <Sidebar />
         <MainPanel toggleMemberList={this.toggleMemberList} />
-        {this.props.channelPanelVisible && <ChannelPanel addr={this.props.addr} channel={cabal.channel} />}
+        {this.props.channelPanelVisible && <ChannelPanel addr={this.props.addr} />}
         {this.props.profilePanelVisible && <ProfilePanel addr={this.props.addr} userKey={this.props.profilePanelUser} />}
       </div>
     )

--- a/app/containers/layout.js
+++ b/app/containers/layout.js
@@ -43,16 +43,6 @@ class LayoutScreen extends Component {
     }))
   }
 
-  cabalsInitialized () {
-    if (this.props.cabals) {
-      return Object.values(this.props.cabals).every((cabal) => {
-        return cabal.initialized
-      })
-    } else {
-      return false
-    }
-  }
-
   render () {
     const { enableDarkmode } = this.props.settings || {}
     if (!this.props.cabalInitialized) {

--- a/app/containers/messages.js
+++ b/app/containers/messages.js
@@ -7,10 +7,12 @@ import {
   showProfilePanel
 } from '../actions'
 import Avatar from './avatar'
+import { currentChannelMessagesSelector, currentChannelSelector } from '../selectors'
 
 const mapStateToProps = state => ({
   addr: state.currentCabal,
-  cabal: state.cabals[state.currentCabal]
+  messages: currentChannelMessagesSelector(state),
+  channel: currentChannelSelector(state)
 })
 
 const mapDispatchToProps = dispatch => ({
@@ -18,7 +20,7 @@ const mapDispatchToProps = dispatch => ({
   showProfilePanel: ({ addr, userKey }) => dispatch(showProfilePanel({ addr, userKey }))
 })
 
-function MessagesContainer(props) {
+function MessagesContainer (props) {
   const onClickProfile = (user) => {
     props.showProfilePanel({
       addr: props.addr,
@@ -35,10 +37,10 @@ function MessagesContainer(props) {
     )
   }
 
-  const messages = props.cabal.messages || []
+  const messages = props.messages || []
   let lastDividerDate = moment() // hold the time of the message for which divider was last added
 
-  if (messages.length === 0 && props.cabal.channel !== '!status') {
+  if (messages.length === 0 && props.channel !== '!status') {
     return (
       <div className='messages starterMessage'>
         This is a new channel. Send a message to start things off!

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -2,8 +2,8 @@ import { createSelector } from '@reduxjs/toolkit'
 import { prop } from 'lodash/fp'
 export const currentCabalSelector = createSelector(
   state => state.currentCabal,
-  state => state.cabals,
-  (currentCabal, cabals) => cabals[currentCabal]
+  state => state.cabals || {},
+  (currentCabal, cabals) => cabals[currentCabal] || {}
 )
 
 function sortUsers(users = []) {
@@ -45,9 +45,23 @@ export const isCabalsInitializedSelector = createSelector(
   }
 )
 
+
 // current cabals settings
 export const cabalSettingsSelector = createSelector(
   state => state?.currentCabal || "",
   state => state.cabalSettings,
   (addr, settings) => settings[addr] || {}
+)
+
+// messages of current cabal
+export const currentChannelMessagesSelector = createSelector(
+  currentCabalSelector,
+  cabal => cabal?.messages || []
+)
+
+
+// select current channel
+export const currentChannelSelector = createSelector(
+  currentCabalSelector,
+  cabal => cabal?.channel
 )

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -47,7 +47,7 @@ export const isCabalsInitializedSelector = createSelector(
 
 // current cabals settings
 export const cabalSettingsSelector = createSelector(
-  state => state?.currentCabal?.addr || "",
+  state => state?.currentCabal || "",
   state => state.cabalSettings,
   (addr, settings) => settings[addr] || {}
 )

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1,12 +1,12 @@
 import { createSelector } from '@reduxjs/toolkit'
-
+import { prop } from 'lodash/fp'
 export const currentCabalSelector = createSelector(
   state => state.currentCabal,
   state => state.cabals,
   (currentCabal, cabals) => cabals[currentCabal]
 )
 
-function sortUsers (users = []) {
+function sortUsers(users = []) {
   if (Array.isArray(users)) {
     return users.sort((a, b) => {
       if (a.isHidden() && !b.isHidden()) return 1
@@ -33,4 +33,21 @@ export const currentChannelMembersSelector = createSelector(
 export const currentChannelMemberCountSelector = createSelector(
   currentChannelMembersSelector,
   (members = []) => members.length
+)
+
+// check if all cabals are initialized and current one is set
+export const isCabalsInitializedSelector = createSelector(
+  state => state.currentCabal,
+  state => state.cabals || {},
+  (current, cabals) => {
+    const cabalsInitialized = Object.values(cabals).every(prop('initialized'))
+    return cabalsInitialized && !!current
+  }
+)
+
+// current cabals settings
+export const cabalSettingsSelector = createSelector(
+  state => state?.currentCabal?.addr || "",
+  state => state.cabalSettings,
+  (addr, settings) => settings[addr] || {}
 )


### PR DESCRIPTION
 The `cabals` property in store updates very often - i.e on new message, or even when a user join/leaves etc - and the main layout component directly subscribing to it causes it to re-render on every small change. Moving the required logic into a selector reduces the unwanted re-rendering of the component. 

p.s: This perf improvement should be applied across other parts of app too, which I am planning to undertake incrementally ^_^