### PR TITLE
UI Fix: Make close button visible in dark mode.

### DIFF
--- a/static/images/icon-composermeta.svg
+++ b/static/images/icon-composermeta.svg
@@ -7,7 +7,7 @@
     <g id="icon-composermeta" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g>
             <rect id="Rectangle-13" x="0" y="0" width="35" height="36"></rect>
-            <g id="Group" opacity="0.5" transform="translate(11.000000, 11.000000)" fill="#000000" fill-rule="nonzero">
+            <g id="Group" transform="translate(11.000000, 11.000000)" fill="#7F7F7F" fill-rule="nonzero">
                 <rect id="Path-Copy" x="0" y="6" width="14" height="2"></rect>
                 <rect id="Path-Copy-2" x="6" y="0" width="2" height="14"></rect>
             </g>


### PR DESCRIPTION
- Close button (cross) is now visible in both dark mode and normal mode.