### PR TITLE
Make profile page close button "sticky"

### DIFF
--- a/app/styles/darkmode.scss
+++ b/app/styles/darkmode.scss
@@ -327,6 +327,10 @@ $textColor2: #aaa;
   }
 
   .profilePanel {
+    .panel__header {
+      background: $backgroundColor;
+    }
+
     .avatar__online__indicator {
       border-color: $backgroundColor;
     }

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -1168,6 +1168,17 @@ form {
 }
 
 .profilePanel {
+  .panel__header {
+    position: absolute;
+    background: #fff;
+    width: 23rem;
+    z-index: 1;
+  }
+
+  .panel__content {
+    margin-top: 4.4rem
+  }
+
   .profile__header {
     align-items: center;
     display: flex;


### PR DESCRIPTION
I thought it would be handy if the panel header would be always visible on top.

![image](https://user-images.githubusercontent.com/7130689/114105300-d0dfa480-98cc-11eb-8bf4-5d2a048a170f.png)
