### PR TITLE
Display self in sidebar and hide controls on profile

### DIFF
--- a/app/containers/profilePanel.js
+++ b/app/containers/profilePanel.js
@@ -92,6 +92,8 @@ function ProfilePanel (props) {
     })
   }
 
+  const isSelf = user.key === props.cabal.userkey
+
   return (
     <div className='panel profilePanel'>
       <div className='panel__header'>
@@ -110,53 +112,58 @@ function ProfilePanel (props) {
           <h1 className='name'>{user.name}</h1>
           <h2 className='key' title={user.key}>{user.key}</h2>
           <div className='sigilContainer'>
-            {user.isAdmin() && <div className='sigil admin'>Admin</div>}
+            {isSelf
+              ? <div className='sigil'>You</div>
+              : user.isAdmin() && <div className='sigil admin'>Admin</div>}
             {user.isModerator() && <div className='sigil moderator'>Moderator</div>}
             {user.isHidden() && <div className='sigil hidden'>Hidden</div>}
           </div>
         </div>
       </div>
-      <div className='section__header'>
-        Moderation
-      </div>
-      <div className='panel__content'>
-        <div className='content__container'>
-          {!user.isHidden() &&
-            <>
-              <button className='button' onClick={onClickHideUserAll}>Hide this peer</button>
-              <div className='help__text'>Hiding a peer hides all of their past and future messages in all channels.</div>
-            </>}
-          {user.isHidden() &&
-            <>
-              <button className='button' onClick={onClickUnhideUserAll}>Unhide this peer</button>
-              <div className='help__text'>Hiding a peer hides all of their past and future messages in all channels.</div>
-            </>}
-          {/* <br />
-          <br />
-          <button className='button' onClick={onClickHideUserAll}>Block this peer</button>
-          <div className='help__text'>Blocking a peer removes all of their messages from your computer. All past and future messages will not be visible, or even known about.</div> */}
-          {!user.isModerator() &&
-            <>
-              <button className='button' onClick={onClickAddModAll}>Add moderator</button>
-              <div className='help__text'>Adding another user as a moderator for you will apply their moderation settings to how you see this cabal.</div>
-            </>}
-          {user.isModerator() &&
-            <>
-              <button className='button' onClick={onClickRemoveModAll}>Remove moderator</button>
-              <div className='help__text'>Adding another user as a moderator for you will apply their moderation settings to how you see this cabal.</div>
-            </>}
-          {!user.isAdmin() &&
-            <>
-              <button className='button' onClick={onClickAddAdminAll}>Add admin</button>
-              <div className='help__text'>Adding another user as an admin for you will apply their moderation settings to how you see this cabal.</div>
-            </>}
-          {user.isAdmin() &&
-            <>
-              <button className='button' onClick={onClickRemoveAdminAll}>Remove admin</button>
-              <div className='help__text'>Adding another user as an admin for you will apply their moderation settings to how you see this cabal.</div>
-            </>}
-        </div>
-      </div>
+      {!isSelf &&
+        <>
+          <div className='section__header'>
+            Moderation
+          </div>
+          <div className='panel__content'>
+            <div className='content__container'>
+              {!user.isHidden() &&
+                <>
+                  <button className='button' onClick={onClickHideUserAll}>Hide this peer</button>
+                  <div className='help__text'>Hiding a peer hides all of their past and future messages in all channels.</div>
+                </>}
+              {user.isHidden() &&
+                <>
+                  <button className='button' onClick={onClickUnhideUserAll}>Unhide this peer</button>
+                  <div className='help__text'>Hiding a peer hides all of their past and future messages in all channels.</div>
+                </>}
+              {/* <br />
+              <br />
+              <button className='button' onClick={onClickHideUserAll}>Block this peer</button>
+              <div className='help__text'>Blocking a peer removes all of their messages from your computer. All past and future messages will not be visible, or even known about.</div> */}
+              {!user.isModerator() &&
+                <>
+                  <button className='button' onClick={onClickAddModAll}>Add moderator</button>
+                  <div className='help__text'>Adding another user as a moderator for you will apply their moderation settings to how you see this cabal.</div>
+                </>}
+              {user.isModerator() &&
+                <>
+                  <button className='button' onClick={onClickRemoveModAll}>Remove moderator</button>
+                  <div className='help__text'>Adding another user as a moderator for you will apply their moderation settings to how you see this cabal.</div>
+                </>}
+              {!user.isAdmin() &&
+                <>
+                  <button className='button' onClick={onClickAddAdminAll}>Add admin</button>
+                  <div className='help__text'>Adding another user as an admin for you will apply their moderation settings to how you see this cabal.</div>
+                </>}
+              {user.isAdmin() &&
+                <>
+                  <button className='button' onClick={onClickRemoveAdminAll}>Remove admin</button>
+                  <div className='help__text'>Adding another user as an admin for you will apply their moderation settings to how you see this cabal.</div>
+                </>}
+            </div>
+          </div>
+        </>}
     </div>
   )
 }

--- a/app/containers/sidebar.js
+++ b/app/containers/sidebar.js
@@ -272,8 +272,8 @@ class SidebarScreen extends React.Component {
                       <span className='messagesUnreadCount'>{unreadNonFavoriteMessageCount}</span>}
                   </div>
                 </div>
-                <div 
-                  className='collection__heading__handle' 
+                <div
+                  className='collection__heading__handle'
                   onClick={this.onClickChannelBrowser.bind(this, cabal.addr)}
                   title='Browse and join or create channels'
                 >
@@ -312,6 +312,7 @@ class SidebarScreen extends React.Component {
                 const isAdmin = peer.users.some((u) => u.isAdmin())
                 const isModerator = peer.users.some((u) => u.isModerator())
                 const isHidden = peer.users.some((u) => u.isHidden())
+                const isSelf = peer.users.some((u) => u.key === userkey)
                 const name = isHidden ? peer.name.substring(0, 3) + peer.key.substring(0, 6) : peer.name
                 return (
                   <div
@@ -334,7 +335,9 @@ class SidebarScreen extends React.Component {
                       </span>
                       {!isAdmin && !isModerator && isHidden && <span className='sigil hidden'>HIDDEN</span>}
                       {!isAdmin && isModerator && <span className='sigil moderator' title='Moderator'>MOD</span>}
-                      {isAdmin && <span className='sigil admin' title='Admin'>ADMIN</span>}
+                      {isSelf
+                        ? <span className='sigil' title='You'>YOU</span>
+                        : isAdmin && <span className='sigil admin' title='Admin'>ADMIN</span>}
                     </div>
                     <div className='collection__item__handle' />
                   </div>


### PR DESCRIPTION
Current user is displayed with a new "YOU" sigil in the sidebar, and moderation controls are hidden for oneself, assuming that it's not useful to deadmin yourself (is it possible though?)

![image](https://user-images.githubusercontent.com/7130689/114142479-4a01ea80-9913-11eb-8a52-e79b00a84602.png)
