### PR TITLE
Add NixOS development tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ $ yarn install             # install dependencies
 $ yarn start               # start the application
 ```
 
+### Build under NixOS
+
+[This gist](https://gist.github.com/cryptix/9dc8806fe44f266d47f550b23b703ff8) contains a `nix-shell` file for development purposes. It sidestepps the issue of packaging the full package tree as a release into nixpkgs.
+
 ### Download from AUR
 https://aur.archlinux.org/packages/cabal-desktop-git/
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ $ yarn start               # start the application
 ```
 
 ### Build under NixOS
-
-[This gist](https://gist.github.com/cryptix/9dc8806fe44f266d47f550b23b703ff8) contains a `nix-shell` file for development purposes. It sidestepps the issue of packaging the full package tree as a release into nixpkgs.
+[This gist](https://gist.github.com/cryptix/9dc8806fe44f266d47f550b23b703ff8) contains a `nix-shell` file for development purposes. It sidesteps the issue of packaging the full package tree as a release into nixpkgs.
 
 ### Download from AUR
 https://aur.archlinux.org/packages/cabal-desktop-git/


### PR DESCRIPTION
This creates a [FHS chroot](https://nixos.org/manual/nixpkgs/stable/#sec-fhs-environments) inside which you can run stuff just like on any other linux/unix system without having to package everything for nixos specificly. 

It's not as nice as packaging for nixpkgs and there might be a bit too much stuff in the `cabalEnv` but it get's the job done.

How to use this:

put the shell.nix inside your checkout of cabal-desktop, run `nix-shell` and start hacking, aka:


```bash
cd repo/of/cabal-desktop
wget https://gist.githubusercontent.com/cryptix/9dc8806fe44f266d47f550b23b703ff8/raw/feb8886a6099a501a2ffc9e0574e818947695dca/shell.nix
nix-shell
npm i
npm start
```

Open to suggestions how to phrase this better on the readme :sweat_smile: 