### PR TITLE
Fix duplicate messages

### DIFF
--- a/app/actions.js
+++ b/app/actions.js
@@ -497,7 +497,7 @@ export const addChannel = ({ addr, channel }) => (dispatch, getState) => {
 
 export const processLine = ({ message, addr }) => dispatch => {
   const text = message.content.text
-  if (text.startsWith('/')) {
+  if (text?.startsWith('/')) {
     const cabal = client.getCurrentCabal()
     cabal.processLine(text)
   } else {
@@ -662,11 +662,11 @@ const initializeCabal = ({ addr, isNewlyAdded, username, settings }) => async di
       }
     }, {
       name: 'info',
-      action: (text) => {
-        console.log('info', text)
-        if (text.startsWith('whispering on')) {
+      action: (info) => {
+        console.log('info', info)
+        if (info?.text?.startsWith('whispering on')) {
           const currentChannel = client.getCurrentChannel()
-          client.addStatusMessage({ text }, currentChannel, cabalDetails._cabal)
+          client.addStatusMessage({ text: info.text }, currentChannel, cabalDetails._cabal)
         }
       }
     }, {
@@ -690,10 +690,7 @@ const initializeCabal = ({ addr, isNewlyAdded, username, settings }) => async di
     }, {
       name: 'publish-message',
       action: () => {
-        const channelMessagesUnread = getCabalUnreadMessagesCount(cabalDetails)
-        const currentChannel = cabalDetails.getCurrentChannel()
-        dispatch(getMessages({ addr, amount: 1000, channel: currentChannel }))
-        dispatch(updateAllsChannelsUnreadCount({ addr, channelMessagesUnread }))
+        // don't do anything on publish message (new-message takes care of it)
       }
     }, {
       name: 'publish-nick',

--- a/app/containers/messages.js
+++ b/app/containers/messages.js
@@ -37,7 +37,11 @@ function MessagesContainer(props) {
     )
   }
 
-  const messages = props.messages || []
+  const messages = (props.messages ?? []).filter((message) => {
+    // Filter out "mention" messages to prevent showing duplicate messages
+    return message?.message?.directMention === undefined
+  })
+
   let lastDividerDate = moment() // hold the time of the message for which divider was last added
 
   if (messages.length === 0 && props.channel !== '!status') {

--- a/app/containers/messages.js
+++ b/app/containers/messages.js
@@ -39,7 +39,7 @@ function MessagesContainer(props) {
 
   const seen = {}
   const messages = (props.messages ?? []).filter((message) => {
-    const messageId = message.time + message.message.seq
+    const messageId = message.key + message.message.seq
     if (typeof seen[messageId] === 'undefined') {
       seen[messageId] = true
       return true

--- a/app/containers/messages.js
+++ b/app/containers/messages.js
@@ -37,9 +37,14 @@ function MessagesContainer(props) {
     )
   }
 
+  const seen = {}
   const messages = (props.messages ?? []).filter((message) => {
-    // Filter out "mention" messages to prevent showing duplicate messages
-    return message?.message?.directMention === undefined
+    const messageId = message.time + message.message.seq
+    if (typeof seen[messageId] === 'undefined') {
+      seen[messageId] = true
+      return true
+    }
+    return false
   })
 
   let lastDividerDate = moment() // hold the time of the message for which divider was last added

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@babel/runtime": "^7.7.7",
     "@reduxjs/toolkit": "^1.3.5",
     "babel-runtime": "^6.26.0",
-    "cabal-client": "6.3.1",
+    "cabal-client": "^6.3.2",
     "collect-stream": "^1.2.1",
     "dat-encoding": "^5.0.1",
     "debug": "^4.1.1",


### PR DESCRIPTION
It seems that Desktop was getting an event from cabal-client about mentions being included or not in the message but didnt handle that correctly and instead showed a full extra message. This PR filters out "mention" messages to prevent showing duplicate messages. 