### PR TITLE
Add a Leave Channel button to PM page

### DIFF
--- a/app/containers/mainPanel.js
+++ b/app/containers/mainPanel.js
@@ -217,6 +217,13 @@ class MainPanel extends Component {
     this.props.showChannelPanel({ addr })
   }
 
+  onClickLeaveChannel (addr) {
+    leaveChannel({
+      addr,
+      channel: currentChannel
+    })
+  }
+
   render () {
     const { cabal, channelMemberCount, settings } = this.props
     var self = this
@@ -289,8 +296,13 @@ class MainPanel extends Component {
                   </h2>
                 </div>
               </div>
-              {!cabal.isChannelPrivate && (
-                <div className='channel-meta__other'>
+              <div className='channel-meta__other'>
+                {cabal.isChannelPrivate && (
+                  <button className='button' onClick={this.onClickLeaveChannel.bind(this, this.props.addr)}>
+                    Leave Channel
+                  </button>
+                )}
+                {!cabal.isChannelPrivate && (
                   <div
                     onClick={this.showChannelPanel.bind(this, this.props.addr)}
                     className='channel-meta__other__more'
@@ -298,8 +310,8 @@ class MainPanel extends Component {
                   >
                     <img src='static/images/icon-channelother.svg' />
                   </div>
-                </div>
-              )}
+                )}
+              </div>
             </div>
           </div>
           <div


### PR DESCRIPTION
Blocked on the release of https://github.com/cabal-club/cabal-client/pull/87 so the cabal-client dependency can also be bumped.

For some reason it isn't working when I test it locally and I can't get the electron devtools to open up so I can debug it, so it's probable that there's a dumb typo somewhere.